### PR TITLE
feat: support more message types

### DIFF
--- a/QQ_History.py
+++ b/QQ_History.py
@@ -61,7 +61,7 @@ class QQoutput():
                 msg += chr(ord(data[i]) ^ ord(self.key[i % len(self.key)]))
             return msg
 
-        if msg_type == -1000 or -1049 or -1051:
+        if msg_type == -1000 or msg_type == -1049 or msg_type == -1051:
             try:
                 return msg.decode('utf-8')
             except:

--- a/QQ_History.py
+++ b/QQ_History.py
@@ -61,7 +61,7 @@ class QQoutput():
                 msg += chr(ord(data[i]) ^ ord(self.key[i % len(self.key)]))
             return msg
 
-        if msg_type == -1000 or -1051:
+        if msg_type == -1000 or -1049 or -1051:
             try:
                 return msg.decode('utf-8')
             except:

--- a/QQ_History.py
+++ b/QQ_History.py
@@ -77,6 +77,8 @@ class QQoutput():
             return self.decode_mix_msg(msg)
         elif msg_type == -5008:
             return self.decode_share_url(msg)
+        elif msg_type == -5012 or msg_type == -5018:
+            return '[戳一戳]'
         # for debug
         # return '[unknown msg_type {}]'.format(msg_type)
         return None

--- a/QQ_History.py
+++ b/QQ_History.py
@@ -7,6 +7,7 @@ import json
 import base64
 from proto.RichMsg_pb2 import PicRec
 from proto.RichMsg_pb2 import Elem
+from proto.RichMsg_pb2 import Msg
 
 _crc64_init = False
 _crc64_table = [0] * 256
@@ -262,12 +263,15 @@ class QQoutput():
 
     def decode_mix_msg(self, data):
         try:
-            doc = Elem()
+            doc = Msg()
             doc.ParseFromString(data)
-            img_src = ''
-            if doc.picMsg:
-                img_src = self.decode_pic(doc.picMsg)
-            return img_src + doc.textMsg.decode('utf-8')
+            message = ''
+            for elem in doc.elems:
+                if elem.picMsg:
+                    message += self.decode_pic(elem.picMsg)
+                else:
+                    message += elem.textMsg.decode('utf-8')
+            return message
         except:
             pass
         return '[混合消息]'

--- a/QQ_History.py
+++ b/QQ_History.py
@@ -61,7 +61,7 @@ class QQoutput():
                 msg += chr(ord(data[i]) ^ ord(self.key[i % len(self.key)]))
             return msg
 
-        if msg_type == -1000:
+        if msg_type == -1000 or -1051:
             try:
                 return msg.decode('utf-8')
             except:


### PR DESCRIPTION
QQ会把太长的消息单独标记，不过也可以使用普通消息的方式解密。另外，回复的消息，回复对象之类的信息存在数据库 extStr 字段里，msgData 存的内容也和普通消息一样。这样的话不如一并当普通消息处理了。